### PR TITLE
Rewrite DB routines

### DIFF
--- a/htdocs/js/main.js
+++ b/htdocs/js/main.js
@@ -17,7 +17,7 @@ require([
 		}
 
 		function save() {
-			$.post('/save', {id: score.id, revision: parseInt(score.revision, 10)+1, code: editor.getValue(), version: $('#version_select_menu input[name=version]:checked').val()}, function(response) {
+			$.post('/save', {id: score.id, code: editor.getValue(), version: $('#version_select_menu input[name=version]:checked').val()}, function(response) {
 				window.location = '/' + response.id + '/' + response.revision;
 			}, 'json');
 		}

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,15 +1,32 @@
 var Promise = require('bluebird');
 const levelup = require('level');
-const db = Promise.promisifyAll(levelup('./data'));
+const db = Promise.promisifyAll(levelup('./data', {
+	valueEncoding: 'json'
+}));
 
-exports.scores = {
-	get: function(id) {
-		return db.getAsync(id)
-			.then(JSON.parse)
+module.exports = {
+	get: function(id, rev) {
+		return db.getAsync(id + ':' + rev)
+	},
+	revisions: function(id) {
+		return db.getAsync(id + ':revisions')
+			.then(null, function (err) {
+				if (err.notFound) return 0;
+				return Promise.reject(err);
+			})
 	},
 	save: function(id, code, version) {
-		return Promise.resolve({code: code, version: version})
-			.then(JSON.stringify)
-			.then(db.putAsync.bind(db, id))
+		var rev;
+		return this.revisions(id)
+			.then(function (revs) {
+				rev = ++revs;
+				return Promise.join(
+					db.putAsync(id + ':revisions', revs),
+					Promise.resolve({code: code, version: version})
+						.then(db.putAsync.bind(db, id + ':' + revs))
+				)
+			}).then(function () {
+				return {id: id, revision: rev};
+			})
 	}
 };

--- a/server.js
+++ b/server.js
@@ -45,14 +45,14 @@ const config = require('./config.json'),
 	versions = {};
 
 // DB
-const db = require('./lib/db');
+const scores = require('./lib/db');
 
 const MAX_ATTEMPTS = 5;
 function getNewId(attempt) {
 	attempt = attempt || 0;
 	const id = Math.random().toString(36).substring(2, 8);
 
-	return db.scores.get(id + ':1').then(function () {
+	return scores.get(id, 1).then(function () {
 		if (++attempt >= MAX_ATTEMPTS) {
 			return Promise.reject(new Error('Too many attempts for new ID'));
 		}
@@ -64,7 +64,6 @@ function getNewId(attempt) {
 
 app.post('/save', function(req, res) {
 	const code = req.body.code,
-		revision = req.body.revision || 1,
 		version = req.body.version || 'stable';
 	var id;
 
@@ -74,9 +73,9 @@ app.post('/save', function(req, res) {
 	}).then(function(_id) {
 		id = _id;
 	}).then(function() {
-		return db.scores.save(id+':'+revision, code, version)
-	}).then(function () {
-		res.send({id: id, revision: revision});
+		return scores.save(id, code, version);
+	}).then(function (info) {
+		res.send(info);
 	}).catch(function (err) {
 		res.status(500).send('Internal server error: ' +
 			(err.text || err.message || '')
@@ -177,7 +176,7 @@ app.get('/:id?/:revision?', function(req, res, next) {
 		});
 	}
 
-	db.scores.get(id+':'+revision)
+	scores.get(id, revision)
 		.then(function (score) {
 			score.id = id;
 			score.revision = revision;


### PR DESCRIPTION
- Add <samp>db.scores.revisions</samp>
- Fixes bug where when saving from <samp>/:id/1</samp>, <samp>/:id/2</samp> is overwritten regardless
  whether it exists or not.