### PR TITLE
Use AWS Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 data
-render

--- a/htdocs/js/main.js
+++ b/htdocs/js/main.js
@@ -34,6 +34,11 @@ require([
 			loadPreview();
 		});
 
+		$.get('https://s3-us-west-2.amazonaws.com/lilybin-tarballs/versions.json', function(data) {
+			$('#version_selection a[data-version="stable"]')  .append(' (' + data.stable   + ')');
+			$('#version_selection a[data-version="unstable"]').append(' (' + data.unstable + ')');
+		});
+
 		function loadPreview() {
 			preview.load({code: editor.getValue(), version: versionState});
 		}

--- a/lib/lilypond.js
+++ b/lib/lilypond.js
@@ -26,11 +26,4 @@ module.exports = {
       });
     });
   },
-
-  versions: function() {
-    return Promise.resolve({
-      stable: '2.18.2',
-      unstable: '2.19.20'
-    })
-  },
 };

--- a/lib/lilypond.js
+++ b/lib/lilypond.js
@@ -1,69 +1,36 @@
 var Promise = require('bluebird');
-var Docker = require('dockerode');
-var through = require('through');
-
-var docker = new Docker();
-
-function exec(cmd, vol) {
-  return new Promise(function(resolve, reject) {
-    var out = '';
-    var stream = through(function write(data) {
-      this.emit('data', data);
-      out += data;
-    });
-
-    var startOpts, runOpts;
-    if (vol) {
-      startOpts = {Volumes: {}};
-      startOpts.Volumes[vol.as] = {};
-      runOpts = {Binds: [vol.mount + ':' + vol.as]};
-    }
-
-    docker.run(
-      'trevordixon/lilypond',
-      cmd,
-      stream,
-      startOpts,
-      runOpts,
-      function (err, data, container) {
-        if (err) reject(err);
-
-        if (data.StatusCode === 0)
-          resolve(out);
-        else reject(out);
-
-        container.remove(function(err, data) {
-          if (err) console.error('Error removing container:', err);
-        });
-      }
-    );
-  });
-
-}
+var AWS = require('aws-sdk');
+var credentials = new AWS.SharedIniFileCredentials({profile: 'lilybin'});
+AWS.config.credentials = credentials;
+AWS.config.region = 'us-west-2'; // See aws/aws-sdk-js#473
+var lambda = new AWS.Lambda({apiVersion: '2015-03-31'});
 
 module.exports = {
-  compile: function(mountDir, scorePath, version) {
+  compile: function(key, body, version) {
     version = (version === 'unstable') ? 'unstable' : 'stable';
 
-    return exec([
-      '/root/' + version + '/bin/lilypond',
-      '--formats=pdf,png',
-      '-o', '/score/rendered',
-      '/score/' + scorePath,
-    ], {
-      mount: mountDir,
-      as: '/score'
+    return new Promise(function (fulfill, reject) {
+      lambda.invoke({
+        FunctionName: 'lilybin-' + version,
+        Payload: JSON.stringify({
+          body   : body,
+          key    : key
+        })
+      }, function (err, data) {
+        if (err) return reject(err);
+        var payload = JSON.parse(data.Payload);
+        if (data.FunctionError) {
+          return reject(new Error(payload.errorMessage));
+        }
+        fulfill(payload);
+      });
     });
   },
 
   versions: function() {
-    var p1 = exec(['/root/stable/bin/lilypond', '-v']);
-    var p2 = exec(['/root/unstable/bin/lilypond', '-v']);
-    return Promise.all([p1, p2]).then(function(o) {
-      var versions = {};
-      versions.stable = o[0].match(/^GNU LilyPond (.*)$/m)[1];
-      versions.unstable = o[1].match(/^GNU LilyPond (.*)$/m)[1];
-      return versions;
-    });
+    return Promise.resolve({
+      stable: '2.18.2',
+      unstable: '2.19.20'
+    })
   },
 };

--- a/package.json
+++ b/package.json
@@ -4,16 +4,14 @@
   "description": "Web-based LilyPond editor",
   "main": "server.js",
   "dependencies": {
+    "aws-sdk": "^2.1.29",
     "bluebird": "^2.9.25",
     "body-parser": "^1.12.3",
     "codemirror": "^5.2.0",
-    "dockerode": "^2.1.3",
     "express": "^4.12.3",
     "level": "^1.0.0-0",
-    "mkdirp": "^0.5.1",
     "normalize.css": "^3.0.3",
     "requirejs": "^2.1.17",
-    "through": "^2.3.7",
     "underscore": "^1.3.1"
   },
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -127,8 +127,7 @@ app.get('/downloadMidi', function(req, res) {
 	res.redirect(BUCKET + id + '.midi');
 });
 
-var versions;
-function handleMain(req, res, next) {
+app.get('/:id?/:revision?', function(req, res, next) {
 	const id = req.params.id,
 		revision = +req.params.revision || 1;
 
@@ -138,15 +137,13 @@ function handleMain(req, res, next) {
 				id: '',
 				code: defaultScore,
 			},
-			versions: versions,
 		});
 	}
 
 	scores.get(id, revision)
 		.then(function (score) {
 			score.id = id;
-			res.render('index.html', {
-				score: score, versions: versions});
+			res.render('index.html', {score: score});
 		}).catch(function(err) {
 			if (err.notFound) {
 				return res.status(404).send('Score not found');
@@ -154,7 +151,7 @@ function handleMain(req, res, next) {
 			res.status(500).send('Internal server error');
 			console.error(err);
 		}).catch(console.error);
-}
+});
 
 app.get('/raw/:id/:revision?', function(req, res, next) {
 	const id = req.params.id,
@@ -173,11 +170,6 @@ app.get('/raw/:id/:revision?', function(req, res, next) {
 		}).catch(console.error);
 });
 
-lilypond.versions().then(function(_versions) {
-	versions = _versions;
-	app.get('/:id?/:revision?', handleMain);
-
-	const port = process.env.LISTEN_PORT || 3001;
-	app.listen(port);
-	console.log('Listening on port ' + port + '.');
-});
+const port = process.env.LISTEN_PORT || 3001;
+app.listen(port);
+console.log('Listening on port ' + port + '.');

--- a/views/index.html
+++ b/views/index.html
@@ -32,10 +32,10 @@
 						<a href="#" id="version_btn" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">LilyPond <span class="caret"></span></a>
 						<ul class="dropdown-menu" id="version_selection" role="menu">
 							<li><a href="#" class="noop-a" data-version="stable">
-								Latest Stable (<%= versions.stable %>)
+								Latest Stable
 							</a></li>
 							<li><a href="#" class="noop-a" data-version="unstable">
-								Latest Unstable (<%= versions.unstable %>)
+								Latest Unstable
 							</a></li>
 						</ul>
 					</li>


### PR DESCRIPTION
As discussed in #34, AWS Lambda makes it effortless to scale up. Currently, when more than say 10 people are using LilyBin simultaneously, the latency is going to go up pretty fast. AWS Lambda solves this problem easily. However, the Lambda containers usually need the first run to warm up (which takes about 2-3 seconds more than usual), but once it is warmed up it runs only marginally slower than the current Docker-based architecture (within 20%).

This minor performance issue would bring much better cost-effectiveness as well, as the first about 20,000 compilations would be completely free on the AWS Lambda's side (counting 20 seconds per compilation), and the cost for S3 would be negligible as well as we can use the Reduced Redundancy Storage and a lifecycle rule that, say, deletes all generated objects older than 1 day. We can then use maybe a less powerful main DigitalOcean box to handle the frontend.

@trevordixon, this will not work if merged as-is, since it is using my S3 bucket and AWS credentials. I can provide instructions on setting it up on your account if needed, but as it is a little convoluted I would suggest simply using my credentials to put on the server. I (well, technically my parents :wink:) can provide for the AWS stuff for at least this entire year.

The sources for AWS Lambda boxes are available at https://github.com/TimothyGu/lilybin-slave. Some documentation is available there as well.

<del>TODO: Fix version detection. I'll probably store the versions as JSON on `s3://lilybin-tarball`, then get it client-side.</del> **Done.** This way the server can run forever without the need to restart it once LilyPond is updated.