### PR TITLE
Use a <textarea> to store source

### DIFF
--- a/htdocs/js/Editor.js
+++ b/htdocs/js/Editor.js
@@ -7,20 +7,11 @@ define([
 	function Editor($container, options) {
 		this.event = $({});
 
-		this.$container = $container.append(
+		this.$container = $container.prepend(
 			this.spinner = $('<div />').css({position: 'absolute', width: '100%', height: '100%'}).spinner({ colour: '100,100,100' }).hide()
 		);
-
-		this.openFile('');
-	}
-	Editor.prototype.openFile = function(contents, loadPreview) {
-		var codemirrorContainer, li;
-
-		this.$container.find('.codemirror_container').hide();
-		this.$container.append(codemirrorContainer = $('<div />').addClass('codemirror_container'));
-
-		this.cm = CodeMirror(codemirrorContainer[0], {
-			value: contents || '',
+		this.textarea = document.getElementById('code');
+		this.cm = CodeMirror.fromTextArea(this.textarea, {
 			lineNumbers: true,
 			fixedGutter: true,
 			matchBrackets: true,
@@ -32,12 +23,14 @@ define([
 				'Ctrl-S': this.save.bind(this)
 			}
 		});
-
-		codemirrorContainer.find('.CodeMirror').css({height: $(window).height() - $('#header').outerHeight() + 'px'});
+	}
+	Editor.prototype.openFile = function(contents, loadPreview) {
+		this.cm.setValue(contents);
 		if (loadPreview) this.loadPreview();
 	}
 	Editor.prototype.getValue = function() {
-		return this.cm.getValue();
+		this.cm.save();
+		return this.textarea.value;
 	};
 	Editor.prototype.undo = function() {
 		return this.cm.undo();

--- a/htdocs/js/main.js
+++ b/htdocs/js/main.js
@@ -57,8 +57,6 @@ require([
 		editor.event.bind({ 'editor:preview': loadPreview,
 		                    'editor:save'   : save });
 
-		editor.openFile(score.code);
-
 		var mainHeight = $(window).height() - $('#header').outerHeight();
 		var mainWidth  = $(window).width();
 		// Corresponds with Bootstrap's xs

--- a/views/index.html
+++ b/views/index.html
@@ -48,7 +48,9 @@
 			</div>
 		</nav>
 		<div id="main">
-			<div class="col-sm-5" id="code_container"></div>
+			<div class="col-sm-5" id="code_container">
+				<textarea id="code"><%= score.code %></textarea>
+			</div>
 			<div class="col-sm-7" id="preview_container">
 				<img id="preview">
 				<div class="preview_controls">


### PR DESCRIPTION
`<textarea>` is more semantic, and makes things simpler.

`Editor#openFile` is now unused, but I'd like to keep it for the time being so that Dropbox support would be easy to add.